### PR TITLE
Fix packaging for pip installation

### DIFF
--- a/klv_system_monitor/__init__.py
+++ b/klv_system_monitor/__init__.py
@@ -1,0 +1,10 @@
+"""Top-level package for KLV System Monitor.
+
+This file enables packaging of the module and exposes the ``main`` entry
+point so it can be invoked as ``klv_system_monitor.main``.
+"""
+
+from .klv_system_monitor import main
+
+__all__ = ["main"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ name = "klv-system-monitor"
 version = "0.1.0"
 description = "Fancy system monitor for everyone"
 readme = "README.md"
-license = "MIT"
-license-files = ["LICENSE"]
+license = {file = "LICENSE"}
 authors = [{name = "Karel López Vilaret", email = "karel.mauricio.lopez.vilaret@uni-oldenburg.de"}]
 keywords = ["BIDS", "DICOM", "GUI", "Neuroimaging"]
 requires-python = ">=3.8"
@@ -22,12 +21,6 @@ dependencies = [
     "pyqtgraph",
     "psutil"
 ]
-
-[project.urls]
-Homepage = ""
-Documentation = ""
-Source = ""
-Tracker = ""
 
 [project.scripts]
 klvtop = "klv_system_monitor.klv_system_monitor:main"


### PR DESCRIPTION
## Summary
- remove invalid project URL stubs and use LICENSE file in `pyproject.toml`
- add `__init__.py` so package can be built and entry point exposed

## Testing
- `python -m pip install --force-reinstall .`


------
https://chatgpt.com/codex/tasks/task_e_68a5efccc2dc83269184c95113340e54