### PR TITLE
Add antialias preference and decouple plot/text refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ written in Python with PyQt5 and psutil. It provides a modern, customizable
 interface inspired by the Ubuntu system monitor, while adding advanced features
 for efficiency, flexibility, and user control.
 
-Recent updates reduce the monitor's own CPU usage by batching per-process
-information retrieval and disabling graph antialiasing by default.
+Recent updates further reduce the monitor's own CPU usage by batching
+per-process information retrieval, decoupling plot and text refresh rates,
+and refreshing the file system view only on demand. Graph antialiasing is
+enabled again for crisp rendering and can now be toggled in Preferences.
 


### PR DESCRIPTION
## Summary
- Re-enable antialiasing and expose it as a preference option
- Allow separate refresh rates for plots vs labels to trim CPU usage
- Refresh File Systems tab on demand and show only real drives

## Testing
- `python -m py_compile klv_system_monitor/klv_system_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a60b3bdab88326b78f241699deb2af