### PR TITLE
Start process refresh on demand and make interval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ Recent updates further reduce the monitor's own CPU usage by batching
 per-process information retrieval, decoupling plot and text refresh rates,
 and refreshing the file system view only on demand. Graph antialiasing is
 enabled again for crisp rendering and can now be toggled in Preferences.
+The Processes tab now updates only when visible, and its refresh interval is
+configurable via the Preferences dialog.
 


### PR DESCRIPTION
## Summary
- refresh processes only when its tab is visible
- allow configuring processes tab refresh interval via Preferences
- document processes tab on-demand refresh

## Testing
- `python -m py_compile klv_system_monitor/klv_system_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6c929e2708326b38301b89bd575a7