### PR TITLE
Increase CPU legend scroll area

### DIFF
--- a/klv_system_monitor/klv_system_monitor.py
+++ b/klv_system_monitor/klv_system_monitor.py
@@ -732,7 +732,7 @@ class ResourcesTab(QtWidgets.QWidget):
         self.cpu_section.add_widget(self.cpu_total_label)
         # Allow the legend area to grow/shrink with the window height
         self.cpu_section.content_layout.setStretch(0, 3)
-        self.cpu_section.content_layout.setStretch(1, 1)
+        self.cpu_section.content_layout.setStretch(1, 2)
         self.cpu_section.default_stretch = 2
 
         self.mem_section = CollapsibleSection("Memory and Swap")


### PR DESCRIPTION
## Summary
- allow CPU legend area to occupy more vertical space before becoming scrollable

## Testing
- `python -m pytest`
- `python -m py_compile klv_system_monitor/klv_system_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a882fa5908832684edcf8f6a260b6e