### PR TITLE
feat: add CPU visualization modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ written in Python with PyQt5 and psutil. It provides a modern, customizable
 interface inspired by the Ubuntu system monitor, while adding advanced features
 for efficiency, flexibility, and user control.
 
+CPU usage can be visualized in three modes—**Multi thread**, **General view**, and
+**Multi window**—selectable from the Preferences dialog.
+
 Recent updates further reduce the monitor's own CPU usage by batching
 per-process information retrieval, decoupling plot and text refresh rates,
 and refreshing the file system view only on demand. Graph antialiasing is


### PR DESCRIPTION
## Summary
- add General view and Multi window CPU graphs
- allow choosing CPU view mode in Preferences and persist choice

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9d51272f083269e6e4a41419d915e