### PR TITLE
Enhance CPU view theming with optional fills and network-only smoothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ for efficiency, flexibility, and user control.
 CPU usage can be visualized in three modes—**Multi thread**, **General view**, and
 **Multi window**—selectable from the Preferences dialog.
 
+Plots adapt to the selected theme, and "Multi window" graphs hide axes while
+showing each core's usage (and frequency when enabled) atop its panel. The
+Preferences dialog also offers options to fill CPU graphs with translucent
+colors and to smooth only the network plot if desired.
+
 Recent updates further reduce the monitor's own CPU usage by batching
 per-process information retrieval, decoupling plot and text refresh rates,
 and refreshing the file system view only on demand. Graph antialiasing is


### PR DESCRIPTION
## Summary
- theme CPU general and per-core mini plots
- hide axes in multi-window mode and display per-core usage/frequency
- add transparent CPU fill option and independent network smoothing toggle

## Testing
- `python -m py_compile klv_system_monitor/klv_system_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9dc5d979883269f6cc707edc0fe10