### PR TITLE
feat: add process deselect and kill options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ enabled again for crisp rendering and can now be toggled in Preferences.
 The Processes tab now updates only when visible, and its refresh interval is
 configurable via the Preferences dialog.
 
+The Processes tab also includes buttons to clear the current selection so the
+view stops following a particular process and to kill selected processes.
+


### PR DESCRIPTION
## Summary
- allow clearing selected processes so view no longer follows them
- add button and confirmation dialog to kill selected processes
- document process controls in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aa083b98448326906f398eabbc4079