### PR TITLE
Ensure root partition is always detected

### DIFF
--- a/klv_system_monitor/klv_system_monitor.py
+++ b/klv_system_monitor/klv_system_monitor.py
@@ -1940,17 +1940,26 @@ class FileSystemsTab(QtWidgets.QWidget):
         seen = set()
         for p in parts:
             if p.mountpoint in seen:
+                # Skip duplicates we've already recorded
                 continue
-            seen.add(p.mountpoint)
             try:
                 usage = psutil.disk_usage(p.mountpoint)
             except Exception:
+                # Skip partitions that psutil cannot inspect
                 continue
+
             # Ensure we have information for all columns
             if not (p.mountpoint and p.fstype):
                 continue
             if usage.total <= 0:
                 continue
+
+            # Mark as seen only after successful validation.  Some
+            # platforms (notably Linux and Windows) may report dummy
+            # entries for the same mount point before the real one. If
+            # we flagged the mount point as seen earlier we could miss
+            # the actual partition, such as the root "/".
+            seen.add(p.mountpoint)
 
             row = self.mounts.rowCount()
             self.mounts.insertRow(row)


### PR DESCRIPTION
## Summary
- fix partition scan to skip duplicates only after valid mount data is collected
- avoid losing the root ("/") or system drive when psutil reports dummy entries

## Testing
- `python -m py_compile klv_system_monitor/klv_system_monitor.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab0ab83c348326b9bde6be8a108e38