### PR TITLE
Make CPU temperature optional and non-blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It takes inspiration from **GNOME/Ubuntu System Monitor** and brings a similarly
 
 ### 1) CPU — General view (single curve)
 Shows total CPU usage over the last 60 seconds with a fixed **0–100%** Y-axis.
-      The average CPU frequency, CPU temperature and total CPU usage are displayed beneath the chart.
+      The average CPU frequency, CPU temperature (when supported) and total CPU usage are displayed beneath the chart.
 Smoothing (EMA) and antialiasing can be enabled/disabled in **Preferences**.
 
 ![CPU – General view](https://raw.githubusercontent.com/karellopez/KLV-System-Monitor/main/assets/general_view.gif)
@@ -31,7 +31,7 @@ Smoothing (EMA) and antialiasing can be enabled/disabled in **Preferences**.
 **How to read this view**
 - **X-axis**: time window (seconds).  
 - **Y-axis**: total CPU utilization (%).  
-- **Footer**: average CPU frequency across cores, CPU temperature, and total CPU usage.
+- **Footer**: average CPU frequency across cores, CPU temperature (if supported), and total CPU usage.
 
 ---
 


### PR DESCRIPTION
## Summary
- fetch CPU temperature on a background thread to keep plots smooth
- hide temperature on Windows and allow toggling it via Preferences
- document that CPU temperature only appears when supported

## Testing
- `python -m py_compile klv_system_monitor/klv_system_monitor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeb69fedb08326bf22d7dd1046ec4d